### PR TITLE
Tests for function returning pointer

### DIFF
--- a/test/function_returning_pointer.cpp
+++ b/test/function_returning_pointer.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+using namespace std;
+
+int* pmax(int* a, int* b){
+  return (*a > *b)?a:b;
+}
+
+int main() {
+  int a,b;
+  cin >> a >> b;
+  cout << *pmax(&a,&b) << endl;
+  return 0;
+}

--- a/test/function_returning_pointer_typedef.cpp
+++ b/test/function_returning_pointer_typedef.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+using namespace std;
+
+typedef int* p_int;
+
+p_int pmax(int* a, int* b){
+  return (*a > *b)?a:b;
+}
+
+int main() {
+  int a,b;
+  cin >> a >> b;
+  cout << *pmax(&a,&b) << endl;
+  return 0;
+}

--- a/test/test.yaml
+++ b/test/test.yaml
@@ -199,6 +199,21 @@
         cpp: "function_pointer.cpp"
         in: "20 33"
         out: "53\n53"
+    function_returning_pointer_typedef:
+      after:
+        - "function_pointer"
+      cases:
+        cpp: "function_returning_pointer_typedef.cpp"
+        in: "20 33"
+        out: "33"
+    function_returning_pointer:
+      after:
+        - "function_pointer"
+        - "function_returning_pointer_typedef"
+      cases:
+        cpp: "function_returning_pointer.cpp"
+        in: "20 33"
+        out: "33"
     random:
       after:
         - "cincout"


### PR DESCRIPTION
Greetings from Russia, comrads!

Thank you, @felixhao28, for this great tool!

I'm trying to make my students use JSCPP for writing simple programs.
I noticed that JSCPP does not allow to declare functions returning pointers without typedef.
It seems to be a bug which could be easily fixed, isn't it?

P. S. I've created two tests, but I cannot fix the error myself =(