### PR TITLE
Bugfix: cstdio/cstring conflict

### DIFF
--- a/src/includes/cstdio.coffee
+++ b/src/includes/cstdio.coffee
@@ -36,9 +36,10 @@ validate_format = (rt, format, params...) ->
 
 module.exports =
   load: (rt) ->
-    rt.include "cstring"
     pchar = rt.normalPointerType(rt.charTypeLiteral)
     stdio = rt.config.stdio;
+
+    _strcpy = require "./shared/cstring_strcpy"
 
     __printf = (format, params...) ->
       if rt.isStringType format.t
@@ -51,7 +52,7 @@ module.exports =
 
     _sprintf = (rt, _this, target, format, params...) ->
       retval = __printf(format, params...)
-      rt.getFunc("global", "strcpy", [pchar, pchar])(rt, null, [target, retval])
+      _strcpy(rt, null, [target, retval])
       rt.val(rt.intTypeLiteral, retval.length)
 
     rt.regFunc(_sprintf, "global", "sprintf", [pchar, pchar, "?"], rt.intTypeLiteral)

--- a/src/includes/cstring.coffee
+++ b/src/includes/cstring.coffee
@@ -1,29 +1,10 @@
 module.exports = load: (rt) ->
   pchar = rt.normalPointerType(rt.charTypeLiteral)
   sizet = rt.primitiveType("unsigned int")
-  rt.regFunc ((rt, _this, dest, src) ->
-    if rt.isArrayType(dest.t) and rt.isArrayType(src.t)
-      srcarr = src.v.target
-      i = src.v.position
-      destarr = dest.v.target
-      j = dest.v.position
-      while i < srcarr.length and j < destarr.length and srcarr[i].v != 0
-        destarr[j] = rt.clone(srcarr[i])
-        i++
-        j++
-      if i is srcarr.length
-        rt.raiseException "source string does not have a pending \"\\0\""
-      else if j is destarr.length - 1
-        rt.raiseException "destination array is not big enough"
-      else
-        destarr[j] = rt.val(rt.charTypeLiteral, 0)
-    else
-      rt.raiseException "destination or source is not an array"
-    dest
-  ), "global", "strcpy", [
-    pchar
-    pchar
-  ], pchar
+
+  _strcpy = require "./shared/cstring_strcpy"
+
+  rt.regFunc _strcpy, "global", "strcpy", [pchar,pchar], pchar
   rt.regFunc ((rt, _this, dest, src, num) ->
     if rt.isArrayType(dest.t) and rt.isArrayType(src.t)
       srcarr = src.v.target

--- a/src/includes/shared/cstring_strcpy.coffee
+++ b/src/includes/shared/cstring_strcpy.coffee
@@ -1,0 +1,20 @@
+module.exports = (rt, _this, dest, src) ->
+
+  if rt.isArrayType(dest.t) and rt.isArrayType(src.t)
+    srcarr = src.v.target
+    i = src.v.position
+    destarr = dest.v.target
+    j = dest.v.position
+    while i < srcarr.length and j < destarr.length and srcarr[i].v != 0
+      destarr[j] = rt.clone(srcarr[i])
+      i++
+      j++
+    if i is srcarr.length
+      rt.raiseException "source string does not have a pending \"\\0\""
+    else if j is destarr.length - 1
+      rt.raiseException "destination array is not big enough"
+    else
+      destarr[j] = rt.val(rt.charTypeLiteral, 0)
+  else
+    rt.raiseException "destination or source is not an array"
+  dest

--- a/test/cstdio_cstring_conflict.cpp
+++ b/test/cstdio_cstring_conflict.cpp
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <string.h>
+
+int main()
+{
+    printf("test - ok");
+    return 0;
+}

--- a/test/test.yaml
+++ b/test/test.yaml
@@ -236,3 +236,7 @@
       cases:
         cpp: "printf.cpp"
         out: "boo\n  -42\n  +42\n00042\n42   \n42.90\n042.90\n\x7f\na\n\"\n10%\n+hello+\n$"
+    library_conflicts:
+      cases:
+        cpp: "cstdio_cstring_conflict.cpp"
+        out: "test - ok"


### PR DESCRIPTION
I moved the function strcpy to a file under /include/shared, so we can reuse this function without loading it with rt.include . By doing this we get rid of the libraries conflict.

this merge fix #24 